### PR TITLE
usage message + force exit when argument wasn't provided.

### DIFF
--- a/setup_project_dir.sh
+++ b/setup_project_dir.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+# Exit if no arguments were provided.
+[ $# -eq 0 ] && { echo "Usage: $0 [target directory]"; exit 1; }
+
 # the first argument passed into the script should be the dir
 # where you want the folder structure setup
 


### PR DESCRIPTION
Hi, Dan.  I saw your post on the Software Carpentry mailing list.

Your script does something unexpected: if you don't supply a command line argument, it will issue "cd " with no argument, which changes to your home directory on many systems.

It then proceeds to create those directories, etc. in the home directory...

This patch prevents that.

Cheers,
--Dave
