### PR TITLE
Fix a couple of issues that happened this morning

### DIFF
--- a/setup_project_dir.sh
+++ b/setup_project_dir.sh
@@ -11,6 +11,9 @@ set -o noclobber
 
 echo "Setting up folder structure in $1"
 
+if [ ! -d "$1" ]; then
+    mkdir $1
+fi
 cd $1
 mkdir doc data src bin results
 

--- a/setup_project_dir.sh
+++ b/setup_project_dir.sh
@@ -35,37 +35,39 @@ echo "Results directory for tracking computational experiments peformed on data"
 echo "Folders created."
 
 cd ..
-echo "# computational-project-cookie-cutter
-A cookie cutter (aka project template) to set up a folder structure for a computational project.
-This is a quick way to setup a folder structure that follows one standard to organize a project.
-This helps with project management, reproducibility, sharing, and publishing your data, analysis, and results.
 
-This project was inspired (and modeled off) by:
-
-[Noble WS 2009 A Quick Guide to Organizing Computational Biology Projects. PLoS Comput Biol 5 7: e1000424. doi:10.1371/journal.pcbi.1000424](http://dx.doi.org/10.1371/journal.pcbi.1000424)
-
-## What it does
-the `setup_project_dir.sh` script creates the following folder structure:
-
-    Path_Provided
-    |- doc/           # directory for documentation, one subdirectory for manuscript
-    |
-    |- data/          # data for storing fixed data sets
-    |
-    |- src/           # any source code
-    |
-    |- bin/           # any compiled binaries or scripts
-    |
-    |- results/       # output for tracking computational experiments performed on data
-
-A README containing a brief blurb is placed in each folder.
-This is because git will not track empty folders and placing a README will
-remind you of what goes in each folder, and also the overall
-folder structure will be retained
-
-If you use a webservice in conjunction with your version control (e.g. github, bitbucket, gitlabs, gitbucket, etc)
-the webservice will be able to render these README and other [markdown](https://help.github.com/articles/markdown-basics/) files automatically.
-
-This project was taken from [this](https://github.com/chendaniely/computational-project-cookie-cutter) github repo" >> README.md
-
+cat > README.md << EOF
+#computational-project-cookie-cutter
+#A cookie cutter (aka project template) to set up a folder structure for a computational project.
+#This is a quick way to setup a folder structure that follows one standard to organize a project.
+#This helps with project management, reproducibility, sharing, and publishing your data, analysis, and results.
+#
+#This project was inspired (and modeled off) by:
+#
+#[Noble WS 2009 A Quick Guide to Organizing Computational Biology Projects. PLoS Comput Biol 5 7: e1000424. doi:10.1371/journal.pcbi.1000424](http://dx.doi.org/10.1371/journal.pcbi.1000424)
+#
+### What it does
+#the \`setup_project_dir.sh\` script creates the following folder structure:
+#
+#    Path_Provided
+#    |- doc/           # directory for documentation, one subdirectory for manuscript
+#    |
+#    |- data/          # data for storing fixed data sets
+#    |
+#    |- src/           # any source code
+#    |
+#    |- bin/           # any compiled binaries or scripts
+#    |
+#    |- results/       # output for tracking computational experiments performed on data
+#
+#A README containing a brief blurb is placed in each folder.
+#This is because git will not track empty folders and placing a README will
+#remind you of what goes in each folder, and also the overall
+#folder structure will be retained
+#
+#If you use a webservice in conjunction with your version control (e.g. github, bitbucket, gitlabs, gitbucket, etc)
+#the webservice will be able to render these README and other [markdown](https://help.github.com/articles/markdown-basics/) files automatically.
+#
+#This project was taken from [this](https://github.com/chendaniely/computational-project-cookie-cutter) github repo
+EOF
 echo "Top-level README.md created"

--- a/setup_project_dir.sh
+++ b/setup_project_dir.sh
@@ -38,36 +38,36 @@ cd ..
 
 cat > README.md << EOF
 #computational-project-cookie-cutter
-#A cookie cutter (aka project template) to set up a folder structure for a computational project.
-#This is a quick way to setup a folder structure that follows one standard to organize a project.
-#This helps with project management, reproducibility, sharing, and publishing your data, analysis, and results.
-#
-#This project was inspired (and modeled off) by:
-#
-#[Noble WS 2009 A Quick Guide to Organizing Computational Biology Projects. PLoS Comput Biol 5 7: e1000424. doi:10.1371/journal.pcbi.1000424](http://dx.doi.org/10.1371/journal.pcbi.1000424)
-#
-### What it does
-#the \`setup_project_dir.sh\` script creates the following folder structure:
-#
-#    Path_Provided
-#    |- doc/           # directory for documentation, one subdirectory for manuscript
-#    |
-#    |- data/          # data for storing fixed data sets
-#    |
-#    |- src/           # any source code
-#    |
-#    |- bin/           # any compiled binaries or scripts
-#    |
-#    |- results/       # output for tracking computational experiments performed on data
-#
-#A README containing a brief blurb is placed in each folder.
-#This is because git will not track empty folders and placing a README will
-#remind you of what goes in each folder, and also the overall
-#folder structure will be retained
-#
-#If you use a webservice in conjunction with your version control (e.g. github, bitbucket, gitlabs, gitbucket, etc)
-#the webservice will be able to render these README and other [markdown](https://help.github.com/articles/markdown-basics/) files automatically.
-#
-#This project was taken from [this](https://github.com/chendaniely/computational-project-cookie-cutter) github repo
+A cookie cutter (aka project template) to set up a folder structure for a computational project.
+This is a quick way to setup a folder structure that follows one standard to organize a project.
+This helps with project management, reproducibility, sharing, and publishing your data, analysis, and results.
+
+This project was inspired (and modeled off) by:
+
+[Noble WS 2009 A Quick Guide to Organizing Computational Biology Projects. PLoS Comput Biol 5 7: e1000424. doi:10.1371/journal.pcbi.1000424](http://dx.doi.org/10.1371/journal.pcbi.1000424)
+
+## What it does
+the \`setup_project_dir.sh\` script creates the following folder structure:
+
+    Path_Provided
+    |- doc/           # directory for documentation, one subdirectory for manuscript
+    |
+    |- data/          # data for storing fixed data sets
+    |
+    |- src/           # any source code
+    |
+    |- bin/           # any compiled binaries or scripts
+    |
+    |- results/       # output for tracking computational experiments performed on data
+
+A README containing a brief blurb is placed in each folder.
+This is because git will not track empty folders and placing a README will
+remind you of what goes in each folder, and also the overall
+folder structure will be retained
+
+If you use a webservice in conjunction with your version control (e.g. github, bitbucket, gitlabs, gitbucket, etc)
+the webservice will be able to render these README and other [markdown](https://help.github.com/articles/markdown-basics/) files automatically.
+
+This project was taken from [this](https://github.com/chendaniely/computational-project-cookie-cutter) github repo
 EOF
 echo "Top-level README.md created"


### PR DESCRIPTION
Basically, it has two fixes:
- the backticks coming from markdown should be escaped with a "\", otherwise the shell will try to run what's inside
- if the target directory doesn't exist, the folder structure is created in the current directory, which maybe is not what you intended to do. This creates the target folder if it doesn't exist.

and an improvement:
- instead of using a long multiline comment and `echo`, use `cat` and a `heredoc`.
